### PR TITLE
feat: provide options to allow customization

### DIFF
--- a/database_options.go
+++ b/database_options.go
@@ -1,0 +1,52 @@
+package colt
+
+import "log"
+
+type Logger interface {
+	Print(v ...interface{})
+	Panic(v ...interface{})
+}
+
+type Option func(db *opts) error
+
+func WithConnectionString(connectionString string) Option {
+	return func(db *opts) error {
+		db.connectionString = connectionString
+		return nil
+	}
+}
+
+func WithDBName(dbName string) Option {
+	return func(db *opts) error {
+		db.dbName = dbName
+		return nil
+	}
+}
+
+func WithLogger(logger Logger) Option {
+	return func(db *opts) error {
+		db.logger = logger
+		return nil
+	}
+}
+
+type opts struct {
+	connectionString string
+	dbName           string
+	logger           Logger
+}
+
+func (d *opts) ConnectionString() string {
+	return d.connectionString
+}
+
+func (d *opts) DBName() string {
+	return d.dbName
+}
+
+func (d *opts) Logger() Logger {
+	if d.logger == nil {
+		return log.Default()
+	}
+	return d.logger
+}


### PR DESCRIPTION
Adds options to the database. As the current way to setup databases is to create the instance manually, `opts` need to be a value to prevent `nil` errors. I made sure that this way is still supported, but if options need to be provided, a call to `colt.New` is required.

This pattern can be extended to allow customizing many things, for example the timeout for used in the `DefaultContext()` (if that is moved into the database).