### PR TITLE
feat: allow creation of multi-key indices

### DIFF
--- a/indexes.go
+++ b/indexes.go
@@ -5,7 +5,16 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func (repo *Collection[T]) CreateIndex(keys bson.M)  error {
+func (repo *Collection[T]) CreateIndex(keys bson.M) error {
+	mod := mongo.IndexModel{
+		Keys: keys, Options: nil,
+	}
+	_, err := repo.collection.Indexes().CreateOne(DefaultContext(), mod)
+
+	return err
+}
+
+func (repo *Collection[T]) CreateMutiKeyIndex(keys bson.D) error {
 	mod := mongo.IndexModel{
 		Keys: keys, Options: nil,
 	}

--- a/indexes_test.go
+++ b/indexes_test.go
@@ -31,3 +31,29 @@ func TestCollection_CreateIndex(t *testing.T) {
 	// new index
 	assert.Equal(t, len(indxs), indexCountBefore+1)
 }
+
+func TestCollection_CreateMultiKeyIndex(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	mockDb.Connect("mongodb://localhost:27017/colt?readPreference=primary&directConnection=true&ssl=false", "colt")
+
+	collection := GetCollection[*testdoc](&mockDb, "testdocs")
+
+	var indxs = []interface{}{}
+	indexCursor, _ := collection.collection.Indexes().List(DefaultContext())
+	indexCursor.All(DefaultContext(), &indxs)
+
+	indexCountBefore := len(indxs)
+
+	err := collection.CreateMutiKeyIndex(bson.D{
+		{fmt.Sprint(rand.Int()), 1},
+		{fmt.Sprint(rand.Int()), 1},
+	})
+
+	assert.Nil(t, err)
+
+	indexCursor2, _ := collection.collection.Indexes().List(DefaultContext())
+	indexCursor2.All(DefaultContext(), &indxs)
+
+	// new index
+	assert.Equal(t, len(indxs), indexCountBefore+1)
+}


### PR DESCRIPTION
`bson.M` cannot be used to create multi-key indices (they don't guarantee the order of the keys, which can make a difference on mongo indices). The mongodb driver does not allow using `bson.M` for that, it features a protection against that (https://jira.mongodb.org/browse/GODRIVER-1810).

This commit adds a `CreateMultiKeyIndex` func, which gets `bson.D`, which is a set of ordered key-value pairs. This is allowed and works as expected.