### PR TITLE
proposal: implement aggregations via typed pipelines as first-class citizen

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -1,0 +1,87 @@
+package colt
+
+import (
+	"context"
+	"go.mongodb.org/mongo-driver/mongo"
+	"sync"
+)
+
+type Cursor[T any] interface {
+	// Next returns the next document in the cursor. If there is an error, it will be returned along with a nil document.
+	// If there are no more documents, both the document and error will be nil, and the ok flag will be false.
+	// Common usage:
+	//
+	//	for {
+	//		doc, err, ok := cursor.Next()
+	//		if !ok {
+	//			break
+	//		}
+	//		if err != nil {
+	//			// handle error
+	//		}
+	//		// do something with doc
+	//	}
+	Next() (*T, error, bool)
+
+	// Value returns the current document in the cursor. If there was an error decoding the document, it will be returned.
+	// If there are no more documents, both the document and error will be nil. It will not advance the cursor, so calling
+	// Value() multiple times will return the same document, if Next() has been called initially. If Next() has not been
+	// called, Value() will return nil, nil.
+	Value() (*T, error)
+
+	// Close closes the cursor. It should be called when the cursor is no longer needed. It is safe to call Close() multiple
+	// times. It is not safe to call Next() or Value() after Close() has been called.
+	Close() error
+}
+
+type cursor[T any] struct {
+	lock       sync.Locker
+	currentVal *T
+	currentErr error
+	isClosed   bool
+
+	ctx    context.Context
+	cursor *mongo.Cursor
+}
+
+func (p *cursor[T]) Next() (*T, error, bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.isClosed {
+		return nil, nil, false
+	}
+
+	ok := p.cursor.Next(p.ctx)
+	if !ok {
+		p.currentVal = nil
+		p.currentErr = nil
+		return nil, nil, false
+	}
+
+	p.currentVal = new(T)
+	p.currentErr = p.cursor.Decode(p.currentVal)
+	return p.currentVal, p.currentErr, true
+}
+
+func (p *cursor[T]) Value() (*T, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.isClosed {
+		return nil, nil
+	}
+
+	return p.currentVal, p.currentErr
+}
+
+func (p *cursor[T]) Close() error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	
+	p.currentVal = nil
+	p.currentErr = nil
+	p.isClosed = true
+
+	return p.cursor.Close(p.ctx)
+}

--- a/database.go
+++ b/database.go
@@ -56,6 +56,6 @@ func GetCollection[T Document](db *Database, collectionName string) *Collection[
 	return &Collection[T]{db.db.Collection(collectionName)}
 }
 
-func GetPipeline[T Document, R any](collection *Collection[T]) *Pipeline[T, R] {
+func Aggregate[T Document, R any](collection *Collection[T]) *Pipeline[T, R] {
 	return &Pipeline[T, R]{collection.collection, make(mongo.Pipeline, 0)}
 }

--- a/database.go
+++ b/database.go
@@ -42,7 +42,7 @@ func (db *Database) Connect(connectionString string, dbName string) error {
 }
 
 func (db *Database) Disconnect() error {
-	err := db.client.Disconnect(DefaultContext());
+	err := db.client.Disconnect(DefaultContext())
 	db.db = nil
 	return err
 }
@@ -54,4 +54,8 @@ func DefaultContext() context.Context {
 
 func GetCollection[T Document](db *Database, collectionName string) *Collection[T] {
 	return &Collection[T]{db.db.Collection(collectionName)}
+}
+
+func GetPipeline[T Document, R any](collection *Collection[T]) *Pipeline[T, R] {
+	return &Pipeline[T, R]{collection.collection, make(mongo.Pipeline, 0)}
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,8 +11,73 @@ type Pipeline[T Document, R any] struct {
 	pipeline   mongo.Pipeline
 }
 
-func (p *Pipeline[T, R]) Match(filter bson.M) *Pipeline[T, R] {
-	p.pipeline = append(p.pipeline, bson.D{{"$match", filter}})
+func (p *Pipeline[T, R]) AddFields(fields bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$addFields", fields}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Bucket(bucket bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$bucket", bucket}})
+	return p
+}
+
+func (p *Pipeline[T, R]) BucketAuto(bucket bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$bucketAuto", bucket}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ChangeStream(changeStream bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$changeStream", changeStream}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ChangeStreamSplitLargeEvents(changeStream bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$changeStream", changeStream}})
+	return p
+}
+
+func (p *Pipeline[T, R]) CollStats(collStats bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$collStats", collStats}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Count(count bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$count", count}})
+	return p
+}
+
+func (p *Pipeline[T, R]) CurrentOp(currentOp bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$currentOp", currentOp}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Densify(densify bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$densify", densify}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Documents(documents bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$documents", documents}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Facet(facet bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$facet", facet}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Fill(fill bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$fill", fill}})
+	return p
+}
+
+func (p *Pipeline[T, R]) GeoNear(geoNear bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$geoNear", geoNear}})
+	return p
+}
+
+func (p *Pipeline[T, R]) GraphLookup(graphLookup bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$graphLookup", graphLookup}})
 	return p
 }
 
@@ -21,12 +86,142 @@ func (p *Pipeline[T, R]) Group(group bson.M) *Pipeline[T, R] {
 	return p
 }
 
+func (p *Pipeline[T, R]) IndexStats(indexStats bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$indexStats", indexStats}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Limit(limit bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$limit", limit}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ListLocalSessions(listLocalSessions bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$listLocalSessions", listLocalSessions}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ListSampledQueries(listSampledQueries bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$listSampledQueries", listSampledQueries}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ListSearchIndexes(listSearchIndexes bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$listSearchIndexes", listSearchIndexes}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ListSessions(listSessions bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$listSessions", listSessions}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Lookup(lookup bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$lookup", lookup}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Match(filter bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$match", filter}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Merge(merge bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$merge", merge}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Out(out bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$out", out}})
+	return p
+}
+
+func (p *Pipeline[T, R]) PlanCacheStats(planCacheStats bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$planCacheStats", planCacheStats}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Project(project bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$project", project}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Redact(redact bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$redact", redact}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ReplaceRoot(replaceRoot bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$replaceRoot", replaceRoot}})
+	return p
+}
+
+func (p *Pipeline[T, R]) ReplaceWith(replaceWith bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$replaceWith", replaceWith}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Sample(sample bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$sample", sample}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Search(search bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$search", search}})
+	return p
+}
+
+func (p *Pipeline[T, R]) SearchMeta(searchMeta bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$searchMeta", searchMeta}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Set(set bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$set", set}})
+	return p
+}
+
+func (p *Pipeline[T, R]) SetWindowFields(setWindowFields bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$setWindowFields", setWindowFields}})
+	return p
+}
+
+func (p *Pipeline[T, R]) SharedDataDistribution(sharedDataDistribution bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$sharedDataDistribution", sharedDataDistribution}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Skip(skip bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$skip", skip}})
+	return p
+}
+
 func (p *Pipeline[T, R]) Sort(sort bson.M) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$sort", sort}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Add(stage bson.D) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) SortByCount(sortByCount bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$sortByCount", sortByCount}})
+	return p
+}
+
+func (p *Pipeline[T, R]) UnionWith(unionWith bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$unionWith", unionWith}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Unset(unset bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$unset", unset}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Unwind(unwind bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$unwind", unwind}})
+	return p
+}
+
+func (p *Pipeline[T, R]) AppendStage(stage bson.D) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, stage)
 	return p
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -11,212 +11,212 @@ type Pipeline[T Document, R any] struct {
 	pipeline   mongo.Pipeline
 }
 
-func (p *Pipeline[T, R]) AddFields(fields bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) AddFields(fields interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$addFields", fields}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Bucket(bucket bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Bucket(bucket interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$bucket", bucket}})
 	return p
 }
 
-func (p *Pipeline[T, R]) BucketAuto(bucket bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) BucketAuto(bucket interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$bucketAuto", bucket}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ChangeStream(changeStream bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ChangeStream(changeStream interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$changeStream", changeStream}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ChangeStreamSplitLargeEvents(changeStream bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ChangeStreamSplitLargeEvents(changeStream interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$changeStream", changeStream}})
 	return p
 }
 
-func (p *Pipeline[T, R]) CollStats(collStats bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) CollStats(collStats interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$collStats", collStats}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Count(count bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Count(count interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$count", count}})
 	return p
 }
 
-func (p *Pipeline[T, R]) CurrentOp(currentOp bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) CurrentOp(currentOp interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$currentOp", currentOp}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Densify(densify bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Densify(densify interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$densify", densify}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Documents(documents bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Documents(documents interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$documents", documents}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Facet(facet bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Facet(facet interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$facet", facet}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Fill(fill bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Fill(fill interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$fill", fill}})
 	return p
 }
 
-func (p *Pipeline[T, R]) GeoNear(geoNear bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) GeoNear(geoNear interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$geoNear", geoNear}})
 	return p
 }
 
-func (p *Pipeline[T, R]) GraphLookup(graphLookup bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) GraphLookup(graphLookup interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$graphLookup", graphLookup}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Group(group bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Group(group interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$group", group}})
 	return p
 }
 
-func (p *Pipeline[T, R]) IndexStats(indexStats bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) IndexStats(indexStats interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$indexStats", indexStats}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Limit(limit bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Limit(limit interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$limit", limit}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ListLocalSessions(listLocalSessions bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ListLocalSessions(listLocalSessions interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$listLocalSessions", listLocalSessions}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ListSampledQueries(listSampledQueries bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ListSampledQueries(listSampledQueries interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$listSampledQueries", listSampledQueries}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ListSearchIndexes(listSearchIndexes bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ListSearchIndexes(listSearchIndexes interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$listSearchIndexes", listSearchIndexes}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ListSessions(listSessions bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ListSessions(listSessions interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$listSessions", listSessions}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Lookup(lookup bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Lookup(lookup interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$lookup", lookup}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Match(filter bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Match(filter interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$match", filter}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Merge(merge bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Merge(merge interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$merge", merge}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Out(out bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Out(out interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$out", out}})
 	return p
 }
 
-func (p *Pipeline[T, R]) PlanCacheStats(planCacheStats bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) PlanCacheStats(planCacheStats interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$planCacheStats", planCacheStats}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Project(project bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Project(project interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$project", project}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Redact(redact bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Redact(redact interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$redact", redact}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ReplaceRoot(replaceRoot bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ReplaceRoot(replaceRoot interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$replaceRoot", replaceRoot}})
 	return p
 }
 
-func (p *Pipeline[T, R]) ReplaceWith(replaceWith bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) ReplaceWith(replaceWith interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$replaceWith", replaceWith}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Sample(sample bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Sample(sample interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$sample", sample}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Search(search bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Search(search interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$search", search}})
 	return p
 }
 
-func (p *Pipeline[T, R]) SearchMeta(searchMeta bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) SearchMeta(searchMeta interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$searchMeta", searchMeta}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Set(set bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Set(set interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$set", set}})
 	return p
 }
 
-func (p *Pipeline[T, R]) SetWindowFields(setWindowFields bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) SetWindowFields(setWindowFields interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$setWindowFields", setWindowFields}})
 	return p
 }
 
-func (p *Pipeline[T, R]) SharedDataDistribution(sharedDataDistribution bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) SharedDataDistribution(sharedDataDistribution interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$sharedDataDistribution", sharedDataDistribution}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Skip(skip bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Skip(skip interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$skip", skip}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Sort(sort bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Sort(sort interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$sort", sort}})
 	return p
 }
 
-func (p *Pipeline[T, R]) SortByCount(sortByCount bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) SortByCount(sortByCount interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$sortByCount", sortByCount}})
 	return p
 }
 
-func (p *Pipeline[T, R]) UnionWith(unionWith bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) UnionWith(unionWith interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$unionWith", unionWith}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Unset(unset bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Unset(unset interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$unset", unset}})
 	return p
 }
 
-func (p *Pipeline[T, R]) Unwind(unwind bson.M) *Pipeline[T, R] {
+func (p *Pipeline[T, R]) Unwind(unwind interface{}) *Pipeline[T, R] {
 	p.pipeline = append(p.pipeline, bson.D{{"$unwind", unwind}})
 	return p
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -1,0 +1,40 @@
+package colt
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"sync"
+)
+
+type Pipeline[T Document, R any] struct {
+	collection *mongo.Collection
+	pipeline   mongo.Pipeline
+}
+
+func (p *Pipeline[T, R]) Match(filter bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$match", filter}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Group(group bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$group", group}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Sort(sort bson.M) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, bson.D{{"$sort", sort}})
+	return p
+}
+
+func (p *Pipeline[T, R]) Add(stage bson.D) *Pipeline[T, R] {
+	p.pipeline = append(p.pipeline, stage)
+	return p
+}
+
+func (p *Pipeline[T, R]) Run() (Cursor[R], error) {
+	c, err := p.collection.Aggregate(DefaultContext(), p.pipeline)
+	if err != nil {
+		return nil, err
+	}
+	return &cursor[R]{&sync.Mutex{}, nil, nil, false, DefaultContext(), c}, nil
+}


### PR DESCRIPTION
Proposed signature:


```go
type TodoCountAggregation_Result struct {
	ID     int    `json:"_id", bson:"_id"`
	UserID string `json:"user_id", bson:"user_id"`
}

func main() {
	// ... some logic initializing a database with a todo collection
	cursor, err := colt.GetCollection[*todo.Todo, TodoCountAggregation_Result](db).
		Group(bson.M{
			"_id": "$user_id",
			"user_id": {
				"$first": "$user_id",
			},
		}).
		Run()

	if err != nil {
		return nil, err
	}
	defer cursor.Close()

	for {
		doc, err, ok := cursor.Next()
		if !ok {
			break
		}
		if err != nil {
			panic(err)
		}

		log.Printf("todos of %s are in the database", doc.UserID)
	}

}
```