### PR TITLE
feat!: Introduce interface for Collection to make it easier to test

### DIFF
--- a/cmd/example.go
+++ b/cmd/example.go
@@ -2,19 +2,20 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/jensteichert/colt"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
 type Database struct {
-	Todos *colt.Collection[*Todo]
+	Todos colt.Collection[*Todo]
 }
 type Todo struct {
 	colt.DocWithTimestamps `bson:",inline"`
-	Title    string `bson:"title" json:"title"`
+	Title                  string `bson:"title" json:"title"`
 }
 
-func(t *Todo) BeforeInsert() error {
+func (t *Todo) BeforeInsert() error {
 	t.DocWithTimestamps.BeforeInsert()
 	fmt.Println("BeforeInsert executed")
 	return nil

--- a/database.go
+++ b/database.go
@@ -52,6 +52,6 @@ func DefaultContext() context.Context {
 	return ctx
 }
 
-func GetCollection[T Document](db *Database, collectionName string) *Collection[T] {
-	return &Collection[T]{db.db.Collection(collectionName)}
+func GetCollection[T Document](db *Database, collectionName string) Collection[T] {
+	return &CollectionImpl[T]{db.db.Collection(collectionName)}
 }

--- a/indexes.go
+++ b/indexes.go
@@ -5,9 +5,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func (repo *Collection[T]) CreateIndex(keys bson.D)  error {
+func (repo *CollectionImpl[T]) CreateIndex(keys bson.D) error {
 	mod := mongo.IndexModel{
-		Keys: keys,
+		Keys:    keys,
 		Options: nil,
 	}
 	_, err := repo.collection.Indexes().CreateOne(DefaultContext(), mod)

--- a/indexes_test.go
+++ b/indexes_test.go
@@ -2,18 +2,19 @@ package colt
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/bson"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 func TestCollection_CreateIndex(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	mockDb.Connect("mongodb://localhost:27017/colt?readPreference=primary&directConnection=true&ssl=false", "colt")
 
-	collection := GetCollection[*testdoc](&mockDb, "testdocs")
+	collection := &CollectionImpl[*testdoc]{collection: mockDb.db.Collection("testdocs")}
 
 	var indxs = []interface{}{}
 	indexCursor, _ := collection.collection.Indexes().List(DefaultContext())
@@ -38,7 +39,7 @@ func TestCollection_CreateMultiKeyIndex(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	mockDb.Connect("mongodb://localhost:27017/colt?readPreference=primary&directConnection=true&ssl=false", "colt")
 
-	collection := GetCollection[*testdoc](&mockDb, "testdocs")
+	collection := &CollectionImpl[*testdoc]{collection: mockDb.db.Collection("testdocs")}
 
 	var indxs = []interface{}{}
 	indexCursor, _ := collection.collection.Indexes().List(DefaultContext())


### PR DESCRIPTION
Currently it is difficult to unit test code that uses colt's `Collection`. It is not possible to mock a `Collection` as it is just a struct and it is not possible to override the underlying Mongo collection as the collection attribute is not exported.

Introducing an interface would make it a breeze to mock a `Collection` and therefore benefit the testability of consumers. However, currently consumers use pointers to a `Collection`, which is no longer possible with this change, therefore making it a breaking change.